### PR TITLE
Carry leaves

### DIFF
--- a/src/bin/rufft.rs
+++ b/src/bin/rufft.rs
@@ -109,18 +109,20 @@ fn main() {
             );
         });
     } else {
-        let mut trajectories: Vec<_> = ffgraph.iter().collect();
-        let trajectories = trajectories.split_off(trajectories.len() - opt.saved_trajectories);
+        let trajectories: Vec<_> = ffgraph.iter().collect();
+        let max_depth = trajectories[trajectories.len() - 1].depth;
 
         trajectories.iter().for_each(|node| {
-            println!(
-                "{} {} {} {:.1} {}",
-                opt.sequence,
-                opt.sequence.len(),
-                node.structure.to_string(),
-                node.energy as f64 * 0.01,
-                node.structure.pairs()
-            );
+            if node.depth == max_depth {
+                println!(
+                    "{} {} {} {:.1} {}",
+                    opt.sequence,
+                    opt.sequence.len(),
+                    node.structure.to_string(),
+                    node.energy as f64 * 0.01,
+                    node.structure.pairs()
+                );
+            }
         });
     }
 }

--- a/src/folding_graph.rs
+++ b/src/folding_graph.rs
@@ -220,13 +220,35 @@ impl RafftGraph {
             }
         }
 
+        // The reference implementation carries _all_ the best structures till the end
+        // Therefore we're adding the previous nodes to the new children
+        for structure_id in nodes {
+            new_children.push((
+                *structure_id,
+                self.inner[*structure_id].sub_nodes.clone(), //vec![],
+                self.inner[*structure_id].structure.clone(),
+                self.inner[*structure_id].energy,
+            ));
+        }
+
         // sort by energy
         new_children.sort_by_key(|child| child.3);
         new_children = new_children[..self.saved_trajectories.min(new_children.len())].to_vec();
 
         let new_nodes: Vec<NodeIndex> = new_children
             .into_iter()
-            .map(|(parent, sub_nodes, pt, energy)| self.insert(parent, sub_nodes, pt, energy))
+            .filter_map(|(parent, sub_nodes, pt, energy)| {
+                let id = self.insert(parent, sub_nodes, pt, energy);
+
+                // We added the previous nodes to new_children.
+                // However, to save some work, we only want to return "real" new children
+                // This .filter_map() does this
+                if id == parent {
+                    None
+                } else {
+                    Some(id)
+                }
+            })
             .collect();
 
         // TODO: not sure yet about the stop condition but I think the way I'm doing it,

--- a/src/folding_graph.rs
+++ b/src/folding_graph.rs
@@ -185,10 +185,11 @@ impl RafftGraph {
         // unfortunately I seem to need this because I don't want to insert first and then remove unnecessary nodes?
         // in the reference implementation this gets passed down during recursion
         // but I think I can leave it locally for now
-        let mut seen: HashSet<String> = HashSet::new();
+        let mut seen: HashSet<String> = HashSet::with_capacity(self.number_of_branches);
 
         // parent, sub_nodes, structure, energy
-        let mut new_children: Vec<(NodeIndex, Vec<EncodedSequence>, PairTable, i32)> = vec![]; // Vec::with_capacity() would be better as soon as I know a good guess for the capacity
+        let mut new_children: Vec<(NodeIndex, Vec<EncodedSequence>, PairTable, i32)> =
+            Vec::with_capacity(self.number_of_branches + nodes.len());
 
         for (structure_id, node_children) in nodes.iter().zip(all_children.iter()) {
             for combined_helix in node_children


### PR DESCRIPTION
This PR allows multiple identical structures in the fast folding graph iff they're the same as their parents.
This results in the same structure as produced by the reference implementation.

However, the stop condition becomes more expensive, as now structures have to be compared pair by pair, whereas previously structures could be compared by their indices in the graph (since there were only unique structures in the graph).
This might be revised when kinetics will be implemented.

With this PR, output corresponds mostly to the reference implementation. There are a few cases where different intermediate structures are discovered, leading to slightly different graphs. This will be investigated.