### PR TITLE
Unique structures

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,6 @@ from scipy.sparse import coo_matrix
 # with optional parameter beta = 0.61
 rates, i_s, j_s = ffgraph.transition_rates()
 trmatrix = coo_matrix((rates, (i_s, j_s))).toarray() # or .tocsr()
+# see also
+#ffgraph.directed_edges()
 ```

--- a/README.md
+++ b/README.md
@@ -60,4 +60,11 @@ from librafft import FastFoldingGraph, set_temperature, set_energy_parameters
 # min_loop_energy = 0.0
 ffgraph = FastFoldingGraph("GGGUUUGCGGUGUAAGUGCAGCCCGUCUUACACCGUGCGGCACAGGCACUAGUACUGAUGUCGUAUACAGGGCUUUUGACAU")
 print(ffgraph.trajectories())
+
+# Afterwards, obtain Metropolis transition rates:
+from scipy.sparse import coo_matrix
+
+# with optional parameter beta = 0.61
+rates, i_s, j_s = ffgraph.transition_rates()
+trmatrix = coo_matrix((rates, (i_s, j_s))).toarray() # or .tocsr()
 ```

--- a/src/bin/rufft.rs
+++ b/src/bin/rufft.rs
@@ -109,20 +109,19 @@ fn main() {
             );
         });
     } else {
-        let trajectories: Vec<_> = ffgraph.iter().collect();
-        let max_depth = trajectories[trajectories.len() - 1].depth;
+        let mut trajectories: Vec<_> = ffgraph.iter().collect();
 
-        trajectories.iter().for_each(|node| {
-            if node.depth == max_depth {
-                println!(
-                    "{} {} {} {:.1} {}",
-                    opt.sequence,
-                    opt.sequence.len(),
-                    node.structure.to_string(),
-                    node.energy as f64 * 0.01,
-                    node.structure.pairs()
-                );
-            }
-        });
+        trajectories.sort_by_key(|node| node.energy);
+
+        for node in &trajectories[..opt.saved_trajectories.min(trajectories.len())] {
+            println!(
+                "{} {} {} {:.1} {}",
+                opt.sequence,
+                opt.sequence.len(),
+                node.structure.to_string(),
+                node.energy as f64 * 0.01,
+                node.structure.pairs()
+            );
+        }
     }
 }

--- a/src/bin/rufft.rs
+++ b/src/bin/rufft.rs
@@ -1,3 +1,4 @@
+use std::io::Write;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
@@ -73,6 +74,13 @@ struct Opt {
         help = "Format output suitable for internal benchmarks"
     )]
     benchmark: bool,
+    #[structopt(
+        parse(from_os_str),
+        long = "output-edges",
+        short = "o",
+        help = "Write edges (pairs of structure indices) to the specified file. The indices correspond to the order of the printed structures."
+    )]
+    outfile: Option<PathBuf>,
 }
 
 fn main() {
@@ -108,6 +116,14 @@ fn main() {
                 node.energy as f64 * 0.01
             );
         });
+
+        if let Some(outfile) = opt.outfile {
+            if let Ok(mut file) = std::fs::File::create(&outfile) {
+                ffgraph.adjacent_indices().for_each(|(i, j)| {
+                    writeln!(file, "{} {}", i, j).unwrap();
+                })
+            }
+        }
     } else {
         let mut trajectories: Vec<_> = ffgraph.iter().collect();
 

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -68,4 +68,9 @@ impl FastFoldingGraph {
 
         Ok(trajectories)
     }
+
+    #[args(beta = "0.61")]
+    fn transition_rates(&self, beta: f64) -> PyResult<(Vec<f64>, Vec<usize>, Vec<usize>)> {
+        Ok(self.inner.transition_rates(beta))
+    }
 }

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -73,4 +73,9 @@ impl FastFoldingGraph {
     fn transition_rates(&self, beta: f64) -> PyResult<(Vec<f64>, Vec<usize>, Vec<usize>)> {
         Ok(self.inner.transition_rates(beta))
     }
+
+    fn directed_edges(&self) -> PyResult<(Vec<usize>, Vec<usize>)> {
+        let (is, js): (Vec<_>, Vec<_>) = self.inner.adjacent_indices().unzip();
+        Ok((is, js))
+    }
 }

--- a/src/folding_graph.rs
+++ b/src/folding_graph.rs
@@ -178,6 +178,17 @@ impl RafftGraph {
         (data, is, js)
     }
 
+    /// Return the directed edges `(i, j)` of the fast folding graph, where `i`, `j` are
+    /// the indices of the participating structures.
+    /// This is the sparse COO format with empty weights.
+    /// The indices correspond to the order of [`iter()`] and the output of `rufft` as well as the python bindings.
+    pub fn adjacent_indices(&self) -> impl Iterator<Item = (usize, usize)> + '_ {
+        self.inner
+            .raw_edges()
+            .iter()
+            .map(|edge| (edge.source().index(), edge.target().index()))
+    }
+
     /// Recursively construct the fast folding graph layer-per-layer.
     ///
     /// _Implementation Detail_: This does not need to be done recursively. In fact, this


### PR DESCRIPTION
The changes from this PR lead to `FastFoldingGraph` only containing unique structures. This changes the output a bit since the structure with the lowest energy discovered does not necessarily appear in the last step. However, Sorting the output according to the energy solves this without problems. 
The advantage here is that the FFG does not need to be post-processed for kinetics.

Additionally, preliminary functionality for output of the connections between structures in the graph (and transition rates) has been added.